### PR TITLE
Add Missing Socket for Ubuntu 16.04

### DIFF
--- a/templates/sysconfig/opendkim.erb
+++ b/templates/sysconfig/opendkim.erb
@@ -13,6 +13,7 @@
 #SOCKET="inet:54321" # listen on all interfaces on port 54321
 #SOCKET="inet:8891@localhost" # listen on loopback on port 12345
 #SOCKET="inet:12345@192.0.2.1" # listen on 192.0.2.1 on port 12345
+SOCKET="<%= @socket %>"
 
 # Set the necessary startup options
 #OPTIONS="-x <%= @configfile %> -P /var/run/opendkim/opendkim.pid"


### PR DESCRIPTION
Without the socket in /etc/default/opendkim, I was unable to start Opendkim in Ubuntu 16.04.1.